### PR TITLE
user-chip-component routes to 404 page fixed

### DIFF
--- a/src/app/modules/shared/components/user-chip/user-chip.component.html
+++ b/src/app/modules/shared/components/user-chip/user-chip.component.html
@@ -1,6 +1,6 @@
 <a
   matRipple
-  [routerLink]="'/profile/' + id"
+  [routerLink]="'/tenant/users/' + id"
   [matTooltip]="size === 'fit' ? name : ''"
   class="chip {{ size }} {{
     status | lowercase


### PR DESCRIPTION
What was the issue
If you click on user chip component to see more data it is routing to a nonexistent route (possibly legacy route)