### PR TITLE
Show Admit User button, when deferredPayment is active

### DIFF
--- a/src/app/modules/events/pages/event-manage-page/event-manage-page.component.html
+++ b/src/app/modules/events/pages/event-manage-page/event-manage-page.component.html
@@ -155,8 +155,18 @@
                   <div>
                     {{ registration.checkInTime | date: 'short' }}
                   </div>
-                }
-                @if (!registration.checkInTime) {
+                } @else if (
+                  event.registrationMode == 'STRIPE' &&
+                  event.deferredPayment &&
+                  !registration.transactions.length
+                ) {
+                  <button
+                    mat-stroked-button
+                    (click)="admitUser(registration.id); $event.stopPropagation()"
+                  >
+                    <span>Admit user</span>
+                  </button>
+                } @else {
                   <button
                     mat-stroked-button
                     (click)="checkin(registration.id)"


### PR DESCRIPTION
Problem                                                                                                                                                            
                                                                                                                                                                       
  When an event uses deferred payment (organizers must admit a participant before they can pay), the following UX issue occurs:                                        
                                                                                                                                                                       
  All participants who sign up appear as "pending." To admit someone, an organizer has to open the users dropdown, and click "Admit user." After admission, the 
  participant has 24 hours to pay, but during this window they're still shown as "pending."                                                                         
                                                                                                                                                                       
  This means organizers cannot distinguish between participants who are waiting for payment approval and those who have already been admitted and are in their 24-hour 
  payment window. For large events, where you can't remember every name, you have to open every single dropdown to check whether someone still needs to be admitted. 
  Since participants sign up at different times, organizers have to repeat this process over and over, scanning through the entire list each time just to find the few
   new people who need to be admitted. This is extremely time-consuming.                                                                                             
                                                                                                                                                                     
  Solution

  Show the "Admit user" button directly in the Check in column (in place of the greyed-out Check in button) when deferred payment is enabled and the participant has   
  not yet been admitted. This makes unadmitted participants immediately visible without expanding any rows.